### PR TITLE
Link GitHub buttons to repo

### DIFF
--- a/src/components/dashboard/footer.tsx
+++ b/src/components/dashboard/footer.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 import { Github, Twitter, Linkedin, Heart, Waves } from "lucide-react";
 
 const socialLinks = [
-  { icon: Github, href: "https://github.com", label: "GitHub" },
+  { icon: Github, href: "https://github.com/Silver-Wolf-Labs/sw-personal", label: "GitHub" },
   { icon: Twitter, href: "https://twitter.com", label: "Twitter" },
   { icon: Linkedin, href: "https://linkedin.com", label: "LinkedIn" },
 ];

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -75,7 +75,7 @@ export function Header({ onGetStarted }: HeaderProps) {
           {/* Actions */}
           <div className="flex items-center gap-3">
             <motion.a
-              href="https://github.com"
+              href="https://github.com/Silver-Wolf-Labs/sw-personal"
               target="_blank"
               rel="noopener noreferrer"
               className="hidden sm:flex items-center justify-center w-10 h-10 rounded-xl bg-secondary hover:bg-secondary/80 transition-colors"


### PR DESCRIPTION
Point header GitHub button to https://github.com/Silver-Wolf-Labs/sw-personal
Point footer GitHub social link to the same repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only outbound GitHub URLs in header/footer with no behavioral or data-handling changes beyond link destination.
> 
> **Overview**
> Updates the GitHub link targets in the dashboard `Header` and `Footer` components to point to `https://github.com/Silver-Wolf-Labs/sw-personal` instead of the generic `https://github.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2d6436045e49e09a9d865999962077fb67df59c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->